### PR TITLE
Make error channel a buffered channel to avoid goroutine getting stuck

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -29,7 +29,7 @@ func (w *tracerWrapper) Connect(ctx context.Context) error {
 	w.Lock()
 	defer w.Unlock()
 	if !w.connected {
-		var connectionErrorChannel = make(chan error)
+		var connectionErrorChannel = make(chan error, 1)
 		go func() {
 			tracer, closer, err := w.cfg.conf.NewTracer(w.cfg.options...)
 			if err == nil {


### PR DESCRIPTION
If the context Done channel is closed, connectionErrorChannel won't be read and goroutine will be stuck.